### PR TITLE
Add Provider Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/worktree

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +781,7 @@ dependencies = [
  "axum",
  "clap",
  "json5",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -1036,6 +1046,35 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = ">=1"
 json5 = ">=1"
 clap = { version = ">=4", features = ["derive"] }
 url = ">=2.5.8"
+regex = ">=1"
 
 [dev-dependencies]
 tower = { version = ">=0.5", features = ["util"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+pub use crate::provider::compatibility::Compatibility;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -41,24 +42,6 @@ pub enum Authorization {
     Bearer,
     XApiKey,
     XGoogApiKey,
-}
-
-#[derive(Debug, Deserialize, Serialize, Default, PartialEq)]
-pub struct Compatibility {
-    #[serde(default)]
-    pub openai_chat: bool,
-    #[serde(default)]
-    pub openai_responses: bool,
-    #[serde(default)]
-    pub anthropic_messages: bool,
-    #[serde(default)]
-    pub gemini_generate_content: bool,
-    #[serde(default)]
-    pub bedrock_model_invoke: bool,
-    #[serde(default)]
-    pub google_generate_content: bool,
-    #[serde(default)]
-    pub google_raw_predict: bool,
 }
 
 impl Config {

--- a/src/provider/compatibility.rs
+++ b/src/provider/compatibility.rs
@@ -1,0 +1,122 @@
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq)]
+pub struct Compatibility {
+    #[serde(default)]
+    pub openai_chat: bool,
+    #[serde(default)]
+    pub openai_responses: bool,
+    #[serde(default)]
+    pub anthropic_messages: bool,
+    #[serde(default)]
+    pub gemini_generate_content: bool,
+    #[serde(default)]
+    pub bedrock_model_invoke: bool,
+    #[serde(default)]
+    pub google_generate_content: bool,
+    #[serde(default)]
+    pub google_raw_predict: bool,
+}
+
+static RE_OPENAI_CHAT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/v1/chat/completions").unwrap());
+static RE_OPENAI_RESPONSES: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/v1/responses").unwrap());
+static RE_ANTHROPIC_MESSAGES: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/v1/messages").unwrap());
+static RE_GEMINI_GENERATE_CONTENT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r":generateContent$").unwrap());
+static RE_BEDROCK_MODEL_INVOKE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^/model/.+/invoke").unwrap());
+static RE_GOOGLE_GENERATE_CONTENT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r":generateContent$").unwrap());
+static RE_GOOGLE_RAW_PREDICT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r":rawPredict$").unwrap());
+
+impl Compatibility {
+    pub fn is_compatible(&self, path: &str) -> bool {
+        (self.openai_chat && RE_OPENAI_CHAT.is_match(path))
+            || (self.openai_responses && RE_OPENAI_RESPONSES.is_match(path))
+            || (self.anthropic_messages && RE_ANTHROPIC_MESSAGES.is_match(path))
+            || (self.gemini_generate_content && RE_GEMINI_GENERATE_CONTENT.is_match(path))
+            || (self.bedrock_model_invoke && RE_BEDROCK_MODEL_INVOKE.is_match(path))
+            || (self.google_generate_content && RE_GOOGLE_GENERATE_CONTENT.is_match(path))
+            || (self.google_raw_predict && RE_GOOGLE_RAW_PREDICT.is_match(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openai_chat() {
+        let c = Compatibility { openai_chat: true, ..Default::default() };
+        assert!(c.is_compatible("/v1/chat/completions"));
+        assert!(c.is_compatible("/v1/chat/completions?stream=true"));
+        assert!(!c.is_compatible("/v1/responses"));
+    }
+
+    #[test]
+    fn openai_responses() {
+        let c = Compatibility { openai_responses: true, ..Default::default() };
+        assert!(c.is_compatible("/v1/responses"));
+        assert!(c.is_compatible("/v1/responses/resp_123"));
+        assert!(!c.is_compatible("/v1/chat/completions"));
+    }
+
+    #[test]
+    fn anthropic_messages() {
+        let c = Compatibility { anthropic_messages: true, ..Default::default() };
+        assert!(c.is_compatible("/v1/messages"));
+        assert!(c.is_compatible("/v1/messages?stream=true"));
+        assert!(!c.is_compatible("/v1/chat/completions"));
+    }
+
+    #[test]
+    fn gemini_generate_content() {
+        let c = Compatibility { gemini_generate_content: true, ..Default::default() };
+        assert!(c.is_compatible("/v1/models/gemini-2.0-flash:generateContent"));
+        assert!(!c.is_compatible("/v1/chat/completions"));
+    }
+
+    #[test]
+    fn bedrock_model_invoke() {
+        let c = Compatibility { bedrock_model_invoke: true, ..Default::default() };
+        assert!(c.is_compatible("/model/us.anthropic.claude-sonnet-4-5/invoke"));
+        assert!(!c.is_compatible("/v1/chat/completions"));
+    }
+
+    #[test]
+    fn google_generate_content() {
+        let c = Compatibility { google_generate_content: true, ..Default::default() };
+        assert!(c.is_compatible("/v1/projects/my-proj/locations/us/publishers/google/models/gemini-2.5-pro:generateContent"));
+        assert!(!c.is_compatible("/v1/chat/completions"));
+    }
+
+    #[test]
+    fn google_raw_predict() {
+        let c = Compatibility { google_raw_predict: true, ..Default::default() };
+        assert!(c.is_compatible(
+            "/v1/projects/my-proj/locations/us/publishers/google/models/claude-opus-4-5:rawPredict"
+        ));
+        assert!(!c.is_compatible("/v1/chat/completions"));
+    }
+
+    #[test]
+    fn no_flags_matches_nothing() {
+        let c = Compatibility::default();
+        assert!(!c.is_compatible("/v1/chat/completions"));
+        assert!(!c.is_compatible("/v1/messages"));
+        assert!(!c.is_compatible("/anything"));
+    }
+
+    #[test]
+    fn unrelated_path_matches_nothing() {
+        let c = Compatibility { openai_chat: true, ..Default::default() };
+        assert!(!c.is_compatible("/health"));
+        assert!(!c.is_compatible("/v2/something"));
+    }
+}

--- a/src/provider/manager.rs
+++ b/src/provider/manager.rs
@@ -1,0 +1,96 @@
+use super::Provider;
+
+pub struct ProviderManager {
+    providers: Vec<Provider>,
+}
+
+impl ProviderManager {
+    pub fn new() -> Self {
+        Self {
+            providers: Vec::new(),
+        }
+    }
+
+    pub fn add(&mut self, provider: Provider) {
+        self.providers.push(provider);
+    }
+
+    pub fn get_for_path(&self, path: &str) -> Option<&Provider> {
+        self.providers
+            .iter()
+            .find(|p| p.compatibility.is_compatible(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config;
+    use crate::provider::compatibility::Compatibility;
+
+    fn make_provider(name: &str, compat: Compatibility) -> Provider {
+        Provider::from_config(&config::Provider {
+            name: name.to_owned(),
+            description: String::new(),
+            baseurl: "https://example.com".to_owned(),
+            models: vec![],
+            apikey: String::new(),
+            authorization: config::Authorization::None,
+            tailnet: false,
+            compatibility: compat,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn returns_matching_provider() {
+        let mut mgr = ProviderManager::new();
+
+        let mut openai_compat = Compatibility::default();
+        openai_compat.openai_chat = true;
+        mgr.add(make_provider("openai", openai_compat));
+
+        let mut anthropic_compat = Compatibility::default();
+        anthropic_compat.anthropic_messages = true;
+        mgr.add(make_provider("anthropic", anthropic_compat));
+
+        let openai = mgr.get_for_path("/v1/chat/completions").unwrap();
+        assert_eq!(openai.name, "openai");
+
+        let anthropic = mgr.get_for_path("/v1/messages").unwrap();
+        assert_eq!(anthropic.name, "anthropic");
+    }
+
+    #[test]
+    fn returns_none_when_no_match() {
+        let mut mgr = ProviderManager::new();
+
+        let mut compat = Compatibility::default();
+        compat.openai_chat = true;
+        mgr.add(make_provider("openai", compat));
+
+        assert!(mgr.get_for_path("/v1/messages").is_none());
+    }
+
+    #[test]
+    fn returns_first_matching_provider() {
+        let mut mgr = ProviderManager::new();
+
+        let mut compat1 = Compatibility::default();
+        compat1.openai_chat = true;
+        mgr.add(make_provider("first", compat1));
+
+        let mut compat2 = Compatibility::default();
+        compat2.openai_chat = true;
+        mgr.add(make_provider("second", compat2));
+
+        let result = mgr.get_for_path("/v1/chat/completions").unwrap();
+        assert_eq!(result.name, "first");
+    }
+
+    #[test]
+    fn empty_manager_returns_none() {
+        let mgr = ProviderManager::new();
+        assert!(mgr.get_for_path("/v1/chat/completions").is_none());
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,12 +1,19 @@
 mod authenticator;
+pub mod compatibility;
+mod manager;
 
 use crate::config;
 use authenticator::{ProviderAuthenticator, build_authenticator};
+use compatibility::Compatibility;
+
+pub use manager::ProviderManager;
 
 pub struct Provider {
+    pub name: String,
     baseurl: reqwest::Url,
     client: reqwest::Client,
     authenticator: Box<dyn ProviderAuthenticator + Send + Sync>,
+    pub compatibility: Compatibility,
 }
 
 impl Provider {
@@ -14,9 +21,11 @@ impl Provider {
         let baseurl = reqwest::Url::parse(&config.baseurl)?;
         let authenticator = build_authenticator(&config.authorization, &config.apikey);
         Ok(Self {
+            name: config.name.clone(),
             baseurl,
             client: reqwest::Client::new(),
             authenticator,
+            compatibility: config.compatibility.clone(),
         })
     }
 


### PR DESCRIPTION
# Provider Manager Plan

## Context
We need a way to route incoming requests to the right provider based on the request path. Each provider declares its API compatibility via the existing `config::Compatibility` struct. A new `ProviderManager` will hold all providers and select the right one for a given path.

## Files to Create
- `src/provider/compatibility.rs` — `Compatibility` struct + `is_compatible` method
- `src/provider/manager.rs` — `ProviderManager` struct

## Files to Modify
- `src/config.rs` — remove `Compatibility` struct, replace with `use crate::provider::compatibility::Compatibility`
- `src/provider/mod.rs` — add `pub mod compatibility; pub mod manager;`, add `compatibility` field to `Provider`, re-export `ProviderManager`

## Design

### 1. `src/provider/compatibility.rs`

Move `Compatibility` struct from `config.rs` to here. Add an `is_compatible(&self, path: &str) -> bool` method.

Each flag maps to a regex pattern. Use the `regex` crate. Patterns are compiled once via `LazyLock` (or similar).

| Flag | Regex |
|---|---|
| `openai_chat` | `^/v1/chat/completions` |
| `openai_responses` | `^/v1/responses` |
| `anthropic_messages` | `^/v1/messages` |
| `gemini_generate_content` | `:generateContent$` |
| `bedrock_model_invoke` | `^/model/.+/invoke` |
| `google_generate_content` | `:generateContent$` |
| `google_raw_predict` | `:rawPredict$` |

Returns `true` if the path matches **any** enabled flag's regex.

Add `regex` to `Cargo.toml` dependencies.

Include unit tests for each flag and for no-match cases.

### 2. `src/config.rs`

- Remove the `Compatibility` struct definition
- Add `use crate::provider::compatibility::Compatibility;` so existing config parsing still works

### 3. `src/provider/manager.rs`

```rust
pub struct ProviderManager {
    providers: Vec<Provider>,
}

impl ProviderManager {
    pub fn new() -> Self;
    pub fn add(&mut self, provider: Provider);
    pub fn get_for_path(&self, path: &str) -> Option<&Provider>;
}
```

`get_for_path` iterates providers and returns the first where `compatibility.is_compatible(path)` returns true.

Include tests with multiple providers having different compatibility flags.

### 4. `src/provider/mod.rs`

- Add `pub mod compatibility;` and `mod manager;`
- Add `compatibility` field to `Provider` struct (type `compatibility::Compatibility`)
- Populate it in `from_config`
- Re-export: `pub use manager::ProviderManager;`

## Verification
- `cargo test` — all existing tests plus new tests in `compatibility.rs` and `manager.rs` pass
- `cargo build` — compiles cleanly
