### PR TITLE
authenticator: Ensure we replace auth header instead of appending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,7 @@ dependencies = [
  "serde",
  "serde_json",
  "temp-env",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = ">=1", features = ["full"] }
 serde = { version = ">=1", features = ["derive"] }
 serde_json = ">=1"
 json5 = ">=1"
+thiserror = ">=2"
 clap = { version = ">=4", features = ["derive"] }
 url = ">=2.5.8"
 regex = ">=1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ async fn proxy_handler(
         }
     };
 
-    let upstream_res = match upstream_req.send().await {
+    let upstream_res = match provider.send(upstream_req).await {
         Ok(r) => r,
         Err(e) => {
             return (

--- a/src/provider/authenticator.rs
+++ b/src/provider/authenticator.rs
@@ -1,14 +1,25 @@
 use crate::config;
 
+#[derive(Debug, thiserror::Error)]
+pub enum AuthenticatorError {
+    #[error("invalid bearer token: {0}")]
+    InvalidBearerToken(reqwest::header::InvalidHeaderValue),
+    #[error("invalid api key for header {header}: {source}")]
+    InvalidApiKey {
+        header: reqwest::header::HeaderName,
+        source: reqwest::header::InvalidHeaderValue,
+    },
+}
+
 pub(super) trait ProviderAuthenticator {
-    fn authenticate(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder;
+    fn authenticate(&self, request: &mut reqwest::Request) -> Result<(), AuthenticatorError>;
 }
 
 struct NoAuth;
 
 impl ProviderAuthenticator for NoAuth {
-    fn authenticate(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        request
+    fn authenticate(&self, _request: &mut reqwest::Request) -> Result<(), AuthenticatorError> {
+        Ok(())
     }
 }
 
@@ -17,19 +28,33 @@ struct BearerAuth {
 }
 
 impl ProviderAuthenticator for BearerAuth {
-    fn authenticate(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        request.bearer_auth(&self.key)
+    fn authenticate(&self, request: &mut reqwest::Request) -> Result<(), AuthenticatorError> {
+        let value = format!("Bearer {}", self.key)
+            .parse()
+            .map_err(AuthenticatorError::InvalidBearerToken)?;
+        request
+            .headers_mut()
+            .insert(reqwest::header::AUTHORIZATION, value);
+        Ok(())
     }
 }
 
 struct ApiKeyAuth {
-    header: String,
+    header: reqwest::header::HeaderName,
     key: String,
 }
 
 impl ProviderAuthenticator for ApiKeyAuth {
-    fn authenticate(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        request.header(&self.header, &self.key)
+    fn authenticate(&self, request: &mut reqwest::Request) -> Result<(), AuthenticatorError> {
+        let value = self
+            .key
+            .parse()
+            .map_err(|source| AuthenticatorError::InvalidApiKey {
+                header: self.header.clone(),
+                source,
+            })?;
+        request.headers_mut().insert(self.header.clone(), value);
+        Ok(())
     }
 }
 
@@ -43,11 +68,11 @@ pub(super) fn build_authenticator(
             key: apikey.to_owned(),
         }),
         config::Authorization::XApiKey => Box::new(ApiKeyAuth {
-            header: "x-api-key".to_owned(),
+            header: reqwest::header::HeaderName::from_static("x-api-key"),
             key: apikey.to_owned(),
         }),
         config::Authorization::XGoogApiKey => Box::new(ApiKeyAuth {
-            header: "x-goog-api-key".to_owned(),
+            header: reqwest::header::HeaderName::from_static("x-goog-api-key"),
             key: apikey.to_owned(),
         }),
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -76,7 +76,7 @@ impl Provider {
     pub fn build_request(
         &self,
         incoming: axum::extract::Request,
-    ) -> Result<reqwest::RequestBuilder, anyhow::Error> {
+    ) -> Result<reqwest::Request, anyhow::Error> {
         let method = incoming.method().clone();
         let uri = incoming.uri().clone();
 
@@ -89,8 +89,21 @@ impl Provider {
 
         let body = reqwest::Body::wrap_stream(body.into_data_stream());
 
-        let request = self.client.request(method, url).headers(headers).body(body);
-        Ok(self.authenticator.authenticate(request))
+        let mut request = self
+            .client
+            .request(method, url)
+            .headers(headers)
+            .body(body)
+            .build()?;
+        self.authenticator.authenticate(&mut request)?;
+        Ok(request)
+    }
+
+    pub async fn send(
+        &self,
+        request: reqwest::Request,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        self.client.execute(request).await
     }
 }
 
@@ -131,8 +144,6 @@ mod tests {
         let provider = test_provider("https://api.anthropic.com", config::Authorization::None, "");
         let req = provider
             .build_request(incoming_request("GET", "/v1/messages", Body::empty()))
-            .unwrap()
-            .build()
             .unwrap();
         assert_eq!(req.url().as_str(), "https://api.anthropic.com/v1/messages");
     }
@@ -146,8 +157,6 @@ mod tests {
         );
         let req = provider
             .build_request(incoming_request("POST", "/v1/chat", Body::empty()))
-            .unwrap()
-            .build()
             .unwrap();
         assert_eq!(
             req.headers().get("authorization").unwrap(),
@@ -164,8 +173,6 @@ mod tests {
         );
         let req = provider
             .build_request(incoming_request("POST", "/v1/messages", Body::empty()))
-            .unwrap()
-            .build()
             .unwrap();
         assert_eq!(req.headers().get("x-api-key").unwrap(), "sk-ant-key");
         assert!(req.headers().get("authorization").is_none());
@@ -180,8 +187,6 @@ mod tests {
         );
         let req = provider
             .build_request(incoming_request("POST", "/v1/models", Body::empty()))
-            .unwrap()
-            .build()
             .unwrap();
         assert_eq!(req.headers().get("x-goog-api-key").unwrap(), "goog-key");
     }
@@ -191,8 +196,6 @@ mod tests {
         let provider = test_provider("https://example.com", config::Authorization::None, "");
         let req = provider
             .build_request(incoming_request("GET", "/health", Body::empty()))
-            .unwrap()
-            .build()
             .unwrap();
         assert!(req.headers().get("authorization").is_none());
         assert!(req.headers().get("x-api-key").is_none());
@@ -208,8 +211,6 @@ mod tests {
                 "/v1/models?limit=10",
                 Body::empty(),
             ))
-            .unwrap()
-            .build()
             .unwrap();
         assert_eq!(
             req.url().as_str(),
@@ -227,8 +228,6 @@ mod tests {
                 "/v1/chat",
                 Body::from(payload.to_vec()),
             ))
-            .unwrap()
-            .build()
             .unwrap();
         assert_eq!(req.method(), "POST");
         assert_eq!(req.url().as_str(), "https://api.example.com/v1/chat");


### PR DESCRIPTION
Before we would append the auth header instead of replacing an existing one.