### PR TITLE
simplify visibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,11 @@
 pub mod app;
+pub mod auth;
 pub mod config;
+pub mod handlers;
 pub mod logging;
 pub mod metrics;
 pub mod provider;
-
-pub(crate) mod auth;
-pub(crate) mod handlers;
-pub(crate) mod trace;
+pub mod trace;
 
 #[cfg(test)]
-pub(crate) mod test_utils;
+pub mod test_utils;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -10,7 +10,7 @@ use tracing::{Span, info};
 use crate::auth;
 
 #[derive(Debug, Clone)]
-pub(crate) struct LacunaMakeSpan;
+pub struct LacunaMakeSpan;
 
 impl MakeSpan<Body> for LacunaMakeSpan {
     fn make_span(&mut self, request: &Request<Body>) -> Span {
@@ -22,7 +22,7 @@ impl MakeSpan<Body> for LacunaMakeSpan {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct LacunaOnResponse;
+pub struct LacunaOnResponse;
 
 impl OnResponse<Body> for LacunaOnResponse {
     fn on_response(self, response: &Response<Body>, latency: std::time::Duration, _span: &Span) {


### PR DESCRIPTION
Make visibility a bit simpler now that I moved it from `main.rs` to `lib.rs`.

This is basically the equivalent to what it was in `main.rs` -- everything is visible if the modules themselves expose things.

Our crate isn't meant to be used by outsiders, it not published, so this has no real impact other than keeping things simple. We don't have to think about what is `pub(crate)` vs what is `pub`.