### PR TITLE
Type safety + FromStr - boilerplate + usable example + usable integration test - unusable unit test

### DIFF
--- a/examples/serve/main.rs
+++ b/examples/serve/main.rs
@@ -1,0 +1,40 @@
+//! Start lacuna with a minimal example config.
+//!
+//! ```sh
+//! cargo run --example serve
+//! ```
+
+use lacuna::app::AppBuilder;
+use lacuna::config::Config;
+use lacuna::provider::{Provider, ProviderManager};
+use std::path::Path;
+use tokio::net::TcpListener;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("serve")
+        .join("serve.config.json");
+    let config = Config::load(&config_path)?;
+
+    lacuna::logging::init(&config.lacuna.logging)?;
+    lacuna::metrics::init();
+
+    let mut manager = ProviderManager::new();
+    for (key, provider_config) in &config.providers {
+        let provider = Provider::from_config(key, provider_config)?;
+        manager.add(provider);
+    }
+
+    let app = AppBuilder::new()
+        .manager(manager)
+        .identity_header(config.lacuna.identity_header)
+        .build();
+
+    let listener = TcpListener::bind("127.0.0.1:3000").await?;
+    println!("listening on {}", listener.local_addr()?);
+
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/examples/serve/serve.config.json
+++ b/examples/serve/serve.config.json
@@ -1,0 +1,21 @@
+{
+    "lacuna": {
+        "logging": {
+            "format": "console",
+            "level": "info"
+        }
+    },
+    "providers": {
+        "openai": {
+            "name": "OpenAI",
+            "baseurl": "https://api.openai.com/v1",
+            "authorization": "bearer",
+            "apikey": "sk-example",
+            "models": ["gpt-4o", "gpt-4o-mini"],
+            "compatibility": {
+                "openai_chat": true,
+                "openai_responses": true
+            }
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,48 +2,30 @@ pub use crate::provider::compatibility::Compatibility;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
+use std::str::FromStr;
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct Config {
-    #[serde(default)]
     pub lacuna: Lacuna,
-
     pub providers: HashMap<String, Provider>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Lacuna {
-    #[serde(default)]
     pub logging: crate::logging::Logging,
-
-    #[serde(default)]
     pub identity_header: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct Provider {
-    #[serde(default)]
     pub name: String,
-
-    #[serde(default)]
     pub description: String,
-
     pub baseurl: String,
-
-    #[serde(default)]
     pub models: Vec<String>,
-
-    #[serde(default)]
     pub apikey: String,
-
-    #[serde(default)]
     pub authorization: Authorization,
-
-    #[serde(default)]
     pub tailnet: bool,
-
-    #[serde(default)]
     pub compatibility: Compatibility,
 }
 
@@ -57,16 +39,20 @@ pub enum Authorization {
     XGoogApiKey,
 }
 
-impl Config {
-    pub fn parse(contents: &str) -> Result<Self, anyhow::Error> {
-        let config: Config = json5::from_str(contents)?;
+impl FromStr for Config {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let config: Config = json5::from_str(s)?;
         Ok(config)
     }
+}
 
+impl Config {
     pub fn load(path: &Path) -> Result<Self, anyhow::Error> {
         let contents = std::fs::read_to_string(path)?;
         let contents = Self::substitute_env_vars(&contents)?;
-        Self::parse(&contents)
+        contents.parse()
     }
 
     fn substitute_env_vars(input: &str) -> Result<String, anyhow::Error> {
@@ -200,7 +186,7 @@ mod tests {
             "bad-key": "bad-value",
           },
         }"#;
-        let err = Config::parse(json).unwrap_err().to_string();
+        let err = Config::from_str(json).unwrap_err().to_string();
         assert!(
             err.contains("unknown field"),
             "expected error to mention 'unknown field', got: {err}"
@@ -304,5 +290,22 @@ mod tests {
         let serialized = serde_json::to_string(&config).unwrap();
         let roundtripped: Config = json5::from_str(&serialized).unwrap();
         assert_eq!(config, roundtripped);
+    }
+
+    #[test]
+    fn bad_log_level_is_rejected() {
+        let json = r#"{
+          "lacuna": {
+            "logging": {
+              "level": "superverbose"
+            }
+          },
+          "providers": {}
+        }"#;
+        let err = Config::from_str(json).unwrap_err().to_string();
+        assert!(
+            err.contains("superverbose"),
+            "expected error to mention the invalid value, got: {err}"
+        );
     }
 }

--- a/src/handlers/ui.rs
+++ b/src/handlers/ui.rs
@@ -11,39 +11,3 @@ pub fn router(assets_path: &Path) -> Router<Arc<ProviderManager>> {
         .route_service("/", ServeFile::new(assets_path.join("index.html")))
         .fallback_service(ServeDir::new(assets_path))
 }
-
-#[cfg(test)]
-mod tests {
-    use axum::body::Body;
-    use axum::http::{Request, StatusCode};
-    use tower::ServiceExt;
-
-    #[tokio::test]
-    async fn test_ui_index() {
-        let response = crate::app::AppBuilder::new()
-            .build()
-            .oneshot(Request::builder().uri("/ui/").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let html = String::from_utf8(body.to_vec()).unwrap();
-        assert!(html.contains("<html"));
-    }
-
-    #[tokio::test]
-    async fn test_root_redirects_to_ui() {
-        let response = crate::app::AppBuilder::new()
-            .build()
-            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
-        assert_eq!(response.headers().get("location").unwrap(), "/ui/");
-    }
-}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,46 +1,47 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Logging {
-    #[serde(default = "Logging::default_format")]
     pub format: LogFormat,
-
-    #[serde(default = "Logging::default_level")]
-    pub level: String,
+    pub level: LogLevel,
 }
 
-impl Default for Logging {
-    fn default() -> Self {
-        Self {
-            format: Self::default_format(),
-            level: Self::default_level(),
-        }
-    }
-}
-
-impl Logging {
-    fn default_format() -> LogFormat {
-        LogFormat::Console
-    }
-
-    fn default_level() -> String {
-        "info".to_owned()
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum LogFormat {
+    #[default]
     Console,
     Json,
 }
 
-pub fn init(logging: &Logging) -> Result<(), anyhow::Error> {
-    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Error,
+    Warn,
+    #[default]
+    Info,
+    Debug,
+    Trace,
+}
 
-    let filter = EnvFilter::try_new(&logging.level)
-        .map_err(|e| anyhow::anyhow!("invalid log level '{}': {e}", logging.level))?;
+impl From<LogLevel> for tracing::Level {
+    fn from(level: LogLevel) -> Self {
+        match level {
+            LogLevel::Error => Self::ERROR,
+            LogLevel::Warn => Self::WARN,
+            LogLevel::Info => Self::INFO,
+            LogLevel::Debug => Self::DEBUG,
+            LogLevel::Trace => Self::TRACE,
+        }
+    }
+}
+
+pub fn init(logging: &Logging) -> anyhow::Result<()> {
+    use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*};
+
+    let filter = LevelFilter::from_level(logging.level.into());
 
     let registry = tracing_subscriber::registry().with(filter);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use tokio::net::TcpListener;
 use tracing::{error, info};
 
+/// An LLM API gateway and proxy
 #[derive(Parser)]
 struct Args {
     /// Path to the providers config file (YAML or JSON)

--- a/src/provider/compatibility.rs
+++ b/src/provider/compatibility.rs
@@ -4,19 +4,12 @@ use std::sync::LazyLock;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq)]
 pub struct Compatibility {
-    #[serde(default)]
     pub openai_chat: bool,
-    #[serde(default)]
     pub openai_responses: bool,
-    #[serde(default)]
     pub anthropic_messages: bool,
-    #[serde(default)]
     pub gemini_generate_content: bool,
-    #[serde(default)]
     pub bedrock_model_invoke: bool,
-    #[serde(default)]
     pub google_generate_content: bool,
-    #[serde(default)]
     pub google_raw_predict: bool,
 }
 

--- a/tests/examples_configs_are_valid.rs
+++ b/tests/examples_configs_are_valid.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use lacuna::config::Config;
 use std::fs;
 use std::path::Path;
+use std::str::FromStr;
 
 #[test]
 fn examples_configs_are_valid() -> Result<(), anyhow::Error> {
@@ -16,7 +17,8 @@ fn examples_configs_are_valid() -> Result<(), anyhow::Error> {
         let path = entry?;
         let contents = fs::read_to_string(&path)
             .with_context(|| format!("failed to read {}", path.display()))?;
-        Config::parse(&contents).with_context(|| format!("failed to parse {}", path.display()))?;
+        Config::from_str(&contents)
+            .with_context(|| format!("failed to parse {}", path.display()))?;
     }
 
     Ok(())

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,0 +1,37 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+fn build_app_with_test_assets() -> axum::Router {
+    let dir = std::env::temp_dir().join("lacuna_test_ui");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("index.html"), "<html><body>test</body></html>").unwrap();
+    lacuna::app::AppBuilder::new().assets_path(&dir).build()
+}
+
+#[tokio::test]
+async fn ui_index() {
+    let response = build_app_with_test_assets()
+        .oneshot(Request::builder().uri("/ui/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let html = String::from_utf8(body.to_vec()).unwrap();
+    assert!(html.contains("<html"));
+}
+
+#[tokio::test]
+async fn root_redirects_to_ui() {
+    let response = build_app_with_test_assets()
+        .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(response.headers().get("location").unwrap(), "/ui/");
+}


### PR DESCRIPTION
Changes:

**Core**
Parse a LogLevel directly in logging config to make it impossible to represent impossible states in the type system
Remove a bunch of #[default] that weren't doing much
Use FromStr to construct objects from strings

**Accessory**
One of the unit test wasn't working because it was setup like an integration test. Turned it into an integration test
Added an example that works with Cargo's command line `cargo run --example serve`
