### PR TITLE
lacuna: count total tokens, rename metrics

### DIFF
--- a/src/http_handlers/metrics.rs
+++ b/src/http_handlers/metrics.rs
@@ -118,15 +118,21 @@ mod tests {
         let body = get_metrics_body(app).await;
         assert!(
             body.contains(
-                r#"lacuna_provider_input_tokens_total{provider="test-tokens",handler="openai_chat_completion",user=""} 10"#
+                r#"lacuna_provider_tokens_input_total{provider="test-tokens",handler="openai_chat_completion",user=""} 10"#
             ),
             "expected input tokens metric line, got:\n{body}"
         );
         assert!(
             body.contains(
-                r#"lacuna_provider_output_tokens_total{provider="test-tokens",handler="openai_chat_completion",user=""} 20"#
+                r#"lacuna_provider_tokens_output_total{provider="test-tokens",handler="openai_chat_completion",user=""} 20"#
             ),
             "expected output tokens metric line, got:\n{body}"
+        );
+        assert!(
+            body.contains(
+                r#"lacuna_provider_tokens_total{provider="test-tokens",handler="openai_chat_completion",user=""} 30"#
+            ),
+            "expected total tokens metric line, got:\n{body}"
         );
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,9 +31,14 @@ pub fn record_response(request_metadata: &RequestMetadata, response_metadata: &R
         ("user", request_metadata.user_identity.clone()),
     ];
     if let Some(tokens) = response_metadata.input_tokens {
-        metrics::counter!("lacuna_provider_input_tokens_total", &labels).increment(tokens);
+        metrics::counter!("lacuna_provider_tokens_input_total", &labels).increment(tokens);
     }
     if let Some(tokens) = response_metadata.output_tokens {
-        metrics::counter!("lacuna_provider_output_tokens_total", &labels).increment(tokens);
+        metrics::counter!("lacuna_provider_tokens_output_total", &labels).increment(tokens);
+    }
+    let total_tokens =
+        response_metadata.input_tokens.unwrap_or(0) + response_metadata.output_tokens.unwrap_or(0);
+    if total_tokens > 0 {
+        metrics::counter!("lacuna_provider_tokens_total", &labels).increment(total_tokens);
     }
 }


### PR DESCRIPTION
Actually prometheus metrics should get_more_specific_as_the_metric_progresses (like iso8601?)

So I am proposing to rename metrics:
- `lacuna_provider_input_tokens_total` -> `lacuna_provider_tokens_input_total`
- `lacuna_provider_output_tokens_total` -> `lacuna_provider_tokens_output_total`

And add:
- `lacuna_provider_tokens_total`