### PR TITLE
call api_type_for_path once per request

### DIFF
--- a/src/http_handlers/proxy.rs
+++ b/src/http_handlers/proxy.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
-use crate::api_type::{ApiTypeHandler, api_type_for_path};
+use crate::api_type::{ApiType, ApiTypeHandler, api_type_for_path};
 
 use crate::auth;
 use crate::inspecting_stream::InspectingStream;
@@ -16,16 +16,14 @@ use crate::request_metadata::RequestMetadata;
 
 async fn forward_to_provider(
     provider: &provider::Provider,
+    api_type: &ApiType,
     request: axum::extract::Request,
 ) -> Response {
     let method = request.method().to_owned();
     let path = request.uri().path().to_owned();
     let user = auth::get_caller_identity(&request);
-    let api_type_handler = api_type_for_path(&path).map(|t| t.handler());
-    let api_type_handler_id = api_type_handler
-        .as_ref()
-        .map(|h| h.id().to_owned())
-        .unwrap_or_default();
+    let api_type_handler = api_type.handler();
+    let api_type_handler_id = api_type_handler.id().to_owned();
 
     let request_metadata = RequestMetadata {
         provider_key: provider.key.clone(),
@@ -88,7 +86,12 @@ pub async fn provider_proxy_handler(
     State(provider): State<Arc<provider::Provider>>,
     request: axum::extract::Request,
 ) -> Response {
-    forward_to_provider(&provider, request).await
+    let path = request.uri().path().to_owned();
+    let api_type = match api_type_for_path(&path) {
+        Some(api_type) => api_type,
+        None => return (StatusCode::NOT_FOUND, "unknown api type for path").into_response(),
+    };
+    forward_to_provider(&provider, &api_type, request).await
 }
 
 pub async fn proxy_handler(
@@ -96,25 +99,24 @@ pub async fn proxy_handler(
     request: axum::extract::Request,
 ) -> Response {
     let path = request.uri().path().to_owned();
-    let provider = match manager.get_for_path(&path) {
-        Some(p) => p,
-        None => return (StatusCode::NOT_FOUND, "no provider found for path").into_response(),
+    let api_type = match api_type_for_path(&path) {
+        Some(api_type) => api_type,
+        None => return (StatusCode::NOT_FOUND, "unknown api type for path").into_response(),
     };
-    forward_to_provider(provider, request).await
+    let provider = match manager.get_for_api_type(&api_type) {
+        Some(p) => p,
+        None => return (StatusCode::NOT_FOUND, "no provider found for api type").into_response(),
+    };
+    forward_to_provider(provider, &api_type, request).await
 }
 
 fn on_response_stream_complete(
     body: Bytes,
     status_code: u16,
     headers: http::HeaderMap,
-    api_type_handler: Option<Box<dyn ApiTypeHandler + Send>>,
+    api_type_handler: Box<dyn ApiTypeHandler + Send>,
     request_metadata: &RequestMetadata,
 ) {
-    let api_type_handler = match api_type_handler {
-        Some(handler) => handler,
-        None => return,
-    };
-
     let mut response_builder = http::Response::builder().status(status_code);
     for (name, value) in headers.iter() {
         response_builder = response_builder.header(name, value);

--- a/src/provider/compatibility.rs
+++ b/src/provider/compatibility.rs
@@ -15,15 +15,20 @@ pub struct Compatibility {
 }
 
 impl Compatibility {
-    pub fn is_compatible(&self, path: &str) -> bool {
+    pub fn is_compatible(&self, api_type: &ApiType) -> bool {
+        match api_type {
+            ApiType::OpenAiChatCompletion => self.openai_chat,
+            ApiType::OpenAiResponses => self.openai_responses,
+            ApiType::AnthropicMessages => self.anthropic_messages,
+            ApiType::GeminiGenerateContent => self.gemini_generate_content,
+            ApiType::BedrockModelInvoke => self.bedrock_model_invoke,
+            ApiType::GoogleGenerateContent => self.google_generate_content,
+            ApiType::GoogleRawPredict => self.google_raw_predict,
+        }
+    }
+    pub fn is_compatible_with_path(&self, path: &str) -> bool {
         match api_type_for_path(path) {
-            Some(ApiType::OpenAiChatCompletion) => self.openai_chat,
-            Some(ApiType::OpenAiResponses) => self.openai_responses,
-            Some(ApiType::AnthropicMessages) => self.anthropic_messages,
-            Some(ApiType::GeminiGenerateContent) => self.gemini_generate_content,
-            Some(ApiType::BedrockModelInvoke) => self.bedrock_model_invoke,
-            Some(ApiType::GoogleGenerateContent) => self.google_generate_content,
-            Some(ApiType::GoogleRawPredict) => self.google_raw_predict,
+            Some(api_type) => self.is_compatible(&api_type),
             None => false,
         }
     }
@@ -36,20 +41,9 @@ mod tests {
     #[test]
     fn no_flags_matches_nothing() {
         let c = Compatibility::default();
-        assert!(!c.is_compatible("/v1/chat/completions"));
-        assert!(!c.is_compatible("/v1/messages"));
-        assert!(!c.is_compatible("/anything"));
-    }
-
-    #[test]
-    fn disabled_flag_rejects_matching_path() {
-        let c = Compatibility {
-            openai_chat: false,
-            anthropic_messages: true,
-            ..Default::default()
-        };
-        assert!(!c.is_compatible("/v1/chat/completions"));
-        assert!(c.is_compatible("/v1/messages"));
+        assert!(!c.is_compatible(&ApiType::OpenAiChatCompletion));
+        assert!(!c.is_compatible(&ApiType::AnthropicMessages));
+        assert!(!c.is_compatible(&ApiType::BedrockModelInvoke));
     }
 
     #[test]
@@ -60,10 +54,10 @@ mod tests {
             bedrock_model_invoke: true,
             ..Default::default()
         };
-        assert!(c.is_compatible("/v1/chat/completions"));
-        assert!(c.is_compatible("/v1/messages"));
-        assert!(c.is_compatible("/model/us.anthropic.claude-sonnet-4-5/invoke"));
-        assert!(!c.is_compatible("/v1/responses"));
+        assert!(c.is_compatible(&ApiType::OpenAiChatCompletion));
+        assert!(c.is_compatible(&ApiType::AnthropicMessages));
+        assert!(c.is_compatible(&ApiType::BedrockModelInvoke));
+        assert!(!c.is_compatible(&ApiType::OpenAiResponses));
     }
 
     #[test]

--- a/src/provider/manager.rs
+++ b/src/provider/manager.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::api_type::ApiType;
+
 use super::Provider;
 
 #[derive(Debug, Default)]
@@ -18,10 +20,10 @@ impl ProviderManager {
         self.providers.insert(key, Arc::new(provider));
     }
 
-    pub fn get_for_path(&self, path: &str) -> Option<&Arc<Provider>> {
+    pub fn get_for_api_type(&self, api_type: &ApiType) -> Option<&Arc<Provider>> {
         self.providers
             .values()
-            .find(|p| p.compatibility.is_compatible(path))
+            .find(|p| p.compatibility.is_compatible(api_type))
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&String, &Arc<Provider>)> {
@@ -55,10 +57,12 @@ mod tests {
             anthropic_compat,
         ));
 
-        let openai = mgr.get_for_path("/v1/chat/completions").unwrap();
+        let openai = mgr
+            .get_for_api_type(&ApiType::OpenAiChatCompletion)
+            .unwrap();
         assert_eq!(openai.name, "openai");
 
-        let anthropic = mgr.get_for_path("/v1/messages").unwrap();
+        let anthropic = mgr.get_for_api_type(&ApiType::AnthropicMessages).unwrap();
         assert_eq!(anthropic.name, "anthropic");
     }
 
@@ -70,12 +74,15 @@ mod tests {
         compat.openai_chat = true;
         mgr.add(make_provider("openai", "https://example.com", compat));
 
-        assert!(mgr.get_for_path("/v1/messages").is_none());
+        assert!(mgr.get_for_api_type(&ApiType::AnthropicMessages).is_none());
     }
 
     #[test]
     fn empty_manager_returns_none() {
         let mgr = ProviderManager::new();
-        assert!(mgr.get_for_path("/v1/chat/completions").is_none());
+        assert!(
+            mgr.get_for_api_type(&ApiType::OpenAiChatCompletion)
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
We should only call `api_type_for_path` once per request.

The current code was doing this:
```
for provider in providers:
    if provider.is_compatible(path)  <--- This calls api_type_for_path
       ....
```