### PR TITLE
protocol: implement amazon_eventstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c0b3e587fbaa5d7f7e870544508af8ce82ea47cd30376e69e1e37c4ac746f79"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca2734c16913a45343b37313605d84e7d8b34a4611598ce1d25b35860a2bed3"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,8 +181,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -178,8 +212,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -194,6 +228,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bitflags"
@@ -212,6 +256,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cc"
@@ -371,6 +425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +514,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -620,7 +689,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -668,6 +737,17 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -678,12 +758,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -694,8 +785,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -728,8 +819,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -746,7 +837,7 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -767,8 +858,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -1022,12 +1113,14 @@ name = "lacuna"
 version = "0.14.0"
 dependencies = [
  "anyhow",
+ "aws-smithy-eventstream",
+ "aws-smithy-types",
  "axum",
  "bytes",
  "clap",
  "futures-core",
  "glob",
- "http",
+ "http 1.4.0",
  "json5",
  "metrics",
  "metrics-exporter-prometheus",
@@ -1198,6 +1291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1334,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -1549,8 +1657,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -2106,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2196,8 +2304,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -2372,6 +2480,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ metrics = ">=0.24"
 metrics-exporter-prometheus = ">=0.16"
 rfc2047-decoder = ">=1.1.0"
 serde_with = ">=3.18.0"
+aws-smithy-eventstream = ">=0.60.19"
+aws-smithy-types = ">=1.4.5"
 
 [dev-dependencies]
 tower = { version = ">=0.5", features = ["util"] }

--- a/src/api_type/anthropic.rs
+++ b/src/api_type/anthropic.rs
@@ -61,30 +61,37 @@ fn is_event_stream(headers: &http::HeaderMap) -> bool {
         .is_some_and(|ct| ct.starts_with("text/event-stream"))
 }
 
-struct AnthropicSseInspector {
-    input_tokens: Option<u64>,
-    output_tokens: Option<u64>,
+pub(crate) struct AnthropicSseInspector {
+    pub(crate) input_tokens: Option<u64>,
+    pub(crate) output_tokens: Option<u64>,
 }
 
-impl Inspector<SseEvent> for AnthropicSseInspector {
-    type Output = ResponseMetadata;
-
-    fn feed(&mut self, event: SseEvent) {
-        if let Ok(evt) = serde_json::from_str::<SseEventType>(&event.data) {
+impl AnthropicSseInspector {
+    /// Process a single Anthropic JSON event string.
+    pub(crate) fn process_event_json(&mut self, json: &str) {
+        if let Ok(evt) = serde_json::from_str::<SseEventType>(json) {
             match evt.r#type.as_str() {
                 "message_start" => {
-                    if let Ok(msg) = serde_json::from_str::<MessageStartData>(&event.data) {
+                    if let Ok(msg) = serde_json::from_str::<MessageStartData>(json) {
                         self.input_tokens = msg.message.usage.input_tokens;
                     }
                 }
                 "message_delta" => {
-                    if let Ok(delta) = serde_json::from_str::<AnthropicDataWithUsage>(&event.data) {
+                    if let Ok(delta) = serde_json::from_str::<AnthropicDataWithUsage>(json) {
                         self.output_tokens = delta.usage.output_tokens;
                     }
                 }
                 _ => {}
             }
         }
+    }
+}
+
+impl Inspector<SseEvent> for AnthropicSseInspector {
+    type Output = ResponseMetadata;
+
+    fn feed(&mut self, event: SseEvent) {
+        self.process_event_json(&event.data);
     }
 
     fn finish(self: Box<Self>) -> Result<ResponseMetadata, anyhow::Error> {

--- a/src/api_type/bedrock/eventstream_inspector.rs
+++ b/src/api_type/bedrock/eventstream_inspector.rs
@@ -1,0 +1,90 @@
+use serde::Deserialize;
+
+use crate::inspector::protocol::amazon_eventstream::EventstreamEvent;
+
+use super::super::anthropic::AnthropicSseInspector;
+use super::super::{Inspector, ResponseMetadata};
+
+/// Bedrock wraps each inner JSON payload in `{"bytes":"<base64>"}`.
+#[derive(Deserialize)]
+struct BedrockEnvelope {
+    bytes: String,
+}
+
+impl Inspector<EventstreamEvent> for AnthropicSseInspector {
+    type Output = ResponseMetadata;
+
+    fn feed(&mut self, event: EventstreamEvent) {
+        if let Ok(envelope) = serde_json::from_slice::<BedrockEnvelope>(&event.payload)
+            && let Ok(decoded) = aws_smithy_types::base64::decode(&envelope.bytes)
+            && let Ok(json_str) = std::str::from_utf8(&decoded)
+        {
+            self.process_event_json(json_str);
+        }
+    }
+
+    fn finish(self: Box<Self>) -> Result<ResponseMetadata, anyhow::Error> {
+        if self.input_tokens.is_none() && self.output_tokens.is_none() {
+            return Err(anyhow::anyhow!("no token usage found in SSE stream"));
+        }
+        let response_metadata = ResponseMetadata {
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+        };
+        Ok(response_metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api_type::anthropic::AnthropicSseInspector;
+    use crate::inspector::protocol::ProtocolInspector;
+    use crate::inspector::protocol::amazon_eventstream::AmazonEventstreamProtocol;
+    use crate::inspector::protocol::amazon_eventstream::testutil::build_eventstream_frame;
+
+    fn wrap_anthropic_event(json: &str) -> Vec<u8> {
+        let b64 = aws_smithy_types::base64::encode(json.as_bytes());
+        let payload = serde_json::json!({"bytes": b64, "p": "abc"});
+        build_eventstream_frame(payload.to_string().as_bytes())
+    }
+
+    #[test]
+    fn inspect_eventstream_response() {
+        let mut inspector: super::super::super::MetadataInspector =
+            Box::new(ProtocolInspector::new(
+                AmazonEventstreamProtocol::default(),
+                AnthropicSseInspector {
+                    input_tokens: None,
+                    output_tokens: None,
+                },
+            ));
+
+        // message_start with input_tokens
+        let frame1 = wrap_anthropic_event(
+            r#"{"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","usage":{"input_tokens":25,"output_tokens":1}}}"#,
+        );
+        inspector.feed(&frame1);
+
+        // content_block_delta (ignored)
+        let frame2 = wrap_anthropic_event(
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi!"}}"#,
+        );
+        inspector.feed(&frame2);
+
+        // message_delta with output_tokens
+        let frame3 = wrap_anthropic_event(
+            r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":150}}"#,
+        );
+        inspector.feed(&frame3);
+
+        // message_stop
+        let frame4 = wrap_anthropic_event(
+            r#"{"type":"message_stop","amazon-bedrock-invocationMetrics":{"inputTokenCount":25,"outputTokenCount":150}}"#,
+        );
+        inspector.feed(&frame4);
+
+        let metadata = inspector.finish().unwrap();
+        assert_eq!(metadata.input_tokens, Some(25));
+        assert_eq!(metadata.output_tokens, Some(150));
+    }
+}

--- a/src/api_type/bedrock/headers_inspector.rs
+++ b/src/api_type/bedrock/headers_inspector.rs
@@ -1,8 +1,8 @@
-use super::{ApiTypeHandler, MetadataInspector, ResponseMetadata, StaticInspector};
+use super::super::{ApiTypeHandler, MetadataInspector, ResponseMetadata, StaticInspector};
 
-pub struct BedrockModelInvokeHandler;
+pub struct BedrockModelInvokeJsonHandler;
 
-impl ApiTypeHandler for BedrockModelInvokeHandler {
+impl ApiTypeHandler for BedrockModelInvokeJsonHandler {
     fn id(&self) -> &'static str {
         "bedrock_model_invoke"
     }
@@ -50,7 +50,7 @@ mod tests {
             ("x-amzn-bedrock-input-token-count", "25"),
             ("x-amzn-bedrock-output-token-count", "150"),
         ]);
-        let inspector = BedrockModelInvokeHandler.inspector(200, &headers);
+        let inspector = BedrockModelInvokeJsonHandler.inspector(200, &headers);
         let metadata = inspector.finish().unwrap();
         assert_eq!(metadata.input_tokens, Some(25));
         assert_eq!(metadata.output_tokens, Some(150));
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     fn inspect_response_missing_headers() {
         let headers = http::HeaderMap::new();
-        let inspector = BedrockModelInvokeHandler.inspector(200, &headers);
+        let inspector = BedrockModelInvokeJsonHandler.inspector(200, &headers);
         let metadata = inspector.finish().unwrap();
         assert_eq!(metadata.input_tokens, None);
         assert_eq!(metadata.output_tokens, None);
@@ -68,9 +68,8 @@ mod tests {
     #[test]
     fn inspect_response_invalid_header() {
         let headers = headers_to_map(&[("x-amzn-bedrock-input-token-count", "not_a_number")]);
-        let inspector = BedrockModelInvokeHandler.inspector(200, &headers);
+        let inspector = BedrockModelInvokeJsonHandler.inspector(200, &headers);
         let metadata = inspector.finish().unwrap();
-        // Invalid headers are silently ignored (unwrap_or(None) in inspector())
         assert_eq!(metadata.input_tokens, None);
         assert_eq!(metadata.output_tokens, None);
     }

--- a/src/api_type/bedrock/mod.rs
+++ b/src/api_type/bedrock/mod.rs
@@ -1,0 +1,37 @@
+mod eventstream_inspector;
+mod headers_inspector;
+
+use crate::inspector::protocol::ProtocolInspector;
+use crate::inspector::protocol::amazon_eventstream::AmazonEventstreamProtocol;
+
+use super::anthropic::AnthropicSseInspector;
+use super::{ApiTypeHandler, MetadataInspector};
+
+pub struct BedrockModelInvokeHandler;
+
+fn is_amazon_event_stream(headers: &http::HeaderMap) -> bool {
+    headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.starts_with("application/vnd.amazon.eventstream"))
+}
+
+impl ApiTypeHandler for BedrockModelInvokeHandler {
+    fn id(&self) -> &'static str {
+        "bedrock_model_invoke"
+    }
+
+    fn inspector(&self, status: u16, headers: &http::HeaderMap) -> MetadataInspector {
+        if is_amazon_event_stream(headers) {
+            Box::new(ProtocolInspector::new(
+                AmazonEventstreamProtocol::default(),
+                AnthropicSseInspector {
+                    input_tokens: None,
+                    output_tokens: None,
+                },
+            ))
+        } else {
+            headers_inspector::BedrockModelInvokeJsonHandler.inspector(status, headers)
+        }
+    }
+}

--- a/src/inspector/protocol/amazon_eventstream.rs
+++ b/src/inspector/protocol/amazon_eventstream.rs
@@ -1,0 +1,113 @@
+use aws_smithy_eventstream::frame::{DecodedFrame, MessageFrameDecoder};
+use bytes::BytesMut;
+
+use super::Protocol;
+
+/// A decoded Amazon EventStream event payload.
+#[derive(Debug)]
+pub struct EventstreamEvent {
+    pub payload: bytes::Bytes,
+}
+
+/// Sans-IO Amazon EventStream binary protocol parser.
+/// Decodes binary eventstream frames and emits `EventstreamEvent` for each complete message.
+#[derive(Debug, Default)]
+pub struct AmazonEventstreamProtocol {
+    decoder: MessageFrameDecoder,
+    buf: BytesMut,
+}
+
+impl Protocol for AmazonEventstreamProtocol {
+    type Output = EventstreamEvent;
+
+    fn feed(&mut self, chunk: &[u8], on_output: &mut dyn FnMut(EventstreamEvent)) {
+        self.buf.extend_from_slice(chunk);
+        loop {
+            match self.decoder.decode_frame(&mut self.buf) {
+                Ok(DecodedFrame::Complete(message)) => {
+                    on_output(EventstreamEvent {
+                        payload: message.payload().to_owned(),
+                    });
+                }
+                Ok(DecodedFrame::Incomplete) => break,
+                Err(_) => break,
+            }
+        }
+    }
+
+    fn finish(&mut self, _on_output: &mut dyn FnMut(EventstreamEvent)) {
+        // All complete frames are emitted during feed().
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod testutil {
+    use aws_smithy_types::event_stream::{Header, HeaderValue, Message};
+
+    /// Build a raw Amazon EventStream binary frame with the given payload.
+    pub(crate) fn build_eventstream_frame(payload: &[u8]) -> Vec<u8> {
+        let message = Message::new_from_parts(
+            vec![
+                Header::new(":event-type", HeaderValue::String("chunk".into())),
+                Header::new(
+                    ":content-type",
+                    HeaderValue::String("application/json".into()),
+                ),
+                Header::new(":message-type", HeaderValue::String("event".into())),
+            ],
+            payload.to_vec(),
+        );
+        let mut buf = Vec::new();
+        aws_smithy_eventstream::frame::write_message_to(&message, &mut buf).unwrap();
+        buf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::testutil::build_eventstream_frame;
+    use super::*;
+
+    #[test]
+    fn decode_single_frame() {
+        let payload = b"hello";
+        let frame = build_eventstream_frame(payload);
+
+        let mut protocol = AmazonEventstreamProtocol::default();
+        let mut events = Vec::new();
+        protocol.feed(&frame, &mut |e| events.push(e));
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].payload.as_ref(), b"hello");
+    }
+
+    #[test]
+    fn decode_multiple_frames() {
+        let frame1 = build_eventstream_frame(b"first");
+        let frame2 = build_eventstream_frame(b"second");
+        let mut combined = frame1;
+        combined.extend_from_slice(&frame2);
+
+        let mut protocol = AmazonEventstreamProtocol::default();
+        let mut events = Vec::new();
+        protocol.feed(&combined, &mut |e| events.push(e));
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].payload.as_ref(), b"first");
+        assert_eq!(events[1].payload.as_ref(), b"second");
+    }
+
+    #[test]
+    fn decode_chunked_frame() {
+        let frame = build_eventstream_frame(b"chunked");
+        let mid = frame.len() / 2;
+
+        let mut protocol = AmazonEventstreamProtocol::default();
+        let mut events = Vec::new();
+        protocol.feed(&frame[..mid], &mut |e| events.push(e));
+        assert!(events.is_empty());
+        protocol.feed(&frame[mid..], &mut |e| events.push(e));
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].payload.as_ref(), b"chunked");
+    }
+}

--- a/src/inspector/protocol/mod.rs
+++ b/src/inspector/protocol/mod.rs
@@ -1,3 +1,4 @@
+pub mod amazon_eventstream;
 pub mod sse;
 pub mod text;
 


### PR DESCRIPTION
Implement an amazon_eventstream protocol and inspector.

The inspector is built on top of `AnthropicStreamInspector`.

There is 3 levels of abstractions here:
1. `vnd.amazon.eventstream`: This content-type is AWS's own event stream protocol. Implemented in `amazon_eventstream.rs`. (just used AWS's lib)
2.  BedrockEnvelope: just a small base64-encoded JSON object. It "wraps" the underlying model.
3. Anthropic SSE events: because at the end of the day, that's what we are wrapping.

Tested end-to-end locally:

<img width="1277" height="505" alt="image" src="https://github.com/user-attachments/assets/90d95afd-9d49-4ee2-9e2f-4056ab9f804f" />

Test setup:
```json
{
  "env": {
    "ANTHROPIC_MODEL": "us.anthropic.claude-opus-4-6-v1",
    "ANTHROPIC_BEDROCK_BASE_URL": "http://localhost:3000/bedrock",
    "CLAUDE_CODE_USE_BEDROCK": "1",
    "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1"
  }
}
```
