### PR TITLE
1/3 IAM auth support

### DIFF
--- a/src/http_handlers/api.rs
+++ b/src/http_handlers/api.rs
@@ -98,11 +98,14 @@ mod tests {
     #[tokio::test]
     async fn test_config() {
         let mut manager = ProviderManager::new();
-        manager.add(make_provider(
-            "test-provider",
-            "https://api.example.com",
-            Default::default(),
-        ));
+        manager.add(
+            make_provider(
+                "test-provider",
+                "https://api.example.com",
+                Default::default(),
+            )
+            .await,
+        );
 
         let response = crate::app::AppBuilder::new()
             .manager(manager)

--- a/src/http_handlers/metrics.rs
+++ b/src/http_handlers/metrics.rs
@@ -49,11 +49,7 @@ mod tests {
         compat.openai_chat = true;
 
         let mut manager = ProviderManager::new();
-        manager.add(make_provider(
-            "test-anon",
-            &format!("http://{addr}"),
-            compat,
-        ));
+        manager.add(make_provider("test-anon", &format!("http://{addr}"), compat).await);
 
         let app = AppBuilder::new().manager(manager).build();
 
@@ -91,11 +87,7 @@ mod tests {
         compat.openai_chat = true;
 
         let mut manager = ProviderManager::new();
-        manager.add(make_provider(
-            "myprovider",
-            &format!("http://{addr}"),
-            compat,
-        ));
+        manager.add(make_provider("myprovider", &format!("http://{addr}"), compat).await);
 
         let app = AppBuilder::new().manager(manager).build();
 
@@ -147,11 +139,7 @@ mod tests {
         compat.openai_chat = true;
 
         let mut manager = ProviderManager::new();
-        manager.add(make_provider(
-            "test-identified",
-            &format!("http://{addr}"),
-            compat,
-        ));
+        manager.add(make_provider("test-identified", &format!("http://{addr}"), compat).await);
 
         let app = AppBuilder::new()
             .manager(manager)

--- a/src/http_handlers/proxy.rs
+++ b/src/http_handlers/proxy.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -106,12 +107,13 @@ async fn try_forward_to_provider(
 
     let upstream_req = provider
         .build_request(request)
-        .map_err(|e| anyhow::anyhow!("failed to build request: {e}"))?;
+        .await
+        .context("failed to build request")?;
 
     let upstream_res = provider
         .send(upstream_req)
         .await
-        .map_err(|e| anyhow::anyhow!("upstream request failed: {e}"))?;
+        .context("upstream request failed")?;
 
     let status = upstream_res.status();
     let model = request_metadata.inspected.model.as_deref();
@@ -251,11 +253,7 @@ mod tests {
         compat.openai_chat = true;
 
         let mut manager = ProviderManager::new();
-        manager.add(make_provider(
-            "provider-key",
-            &format!("http://{addr}"),
-            compat,
-        ));
+        manager.add(make_provider("provider-key", &format!("http://{addr}"), compat).await);
 
         let response = crate::app::AppBuilder::new()
             .manager(manager)
@@ -288,7 +286,7 @@ mod tests {
         compat.openai_chat = true;
 
         let mut manager = ProviderManager::new();
-        manager.add(make_provider("myopenai", &format!("http://{addr}"), compat));
+        manager.add(make_provider("myopenai", &format!("http://{addr}"), compat).await);
 
         let response = crate::app::AppBuilder::new()
             .manager(manager)
@@ -324,11 +322,7 @@ mod tests {
         let compat = Compatibility::default();
 
         let mut manager = ProviderManager::new();
-        manager.add(make_provider(
-            "myprovider",
-            &format!("http://{addr}"),
-            compat,
-        ));
+        manager.add(make_provider("myprovider", &format!("http://{addr}"), compat).await);
 
         let response = crate::app::AppBuilder::new()
             .manager(manager)
@@ -358,11 +352,14 @@ mod tests {
         let addr = spawn_echo_server().await;
 
         let mut manager = ProviderManager::new();
-        manager.add(make_provider(
-            "myprovider",
-            &format!("http://{addr}"),
-            Compatibility::default(),
-        ));
+        manager.add(
+            make_provider(
+                "myprovider",
+                &format!("http://{addr}"),
+                Compatibility::default(),
+            )
+            .await,
+        );
 
         let app = crate::app::AppBuilder::new()
             .manager(manager)
@@ -439,7 +436,7 @@ mod tests {
                         .to_owned(),
                 ),
             }],
-        ));
+        ).await);
 
         let response = crate::app::AppBuilder::new()
             .manager(manager)
@@ -473,15 +470,18 @@ mod tests {
         let addr = spawn_echo_server().await;
 
         let mut manager = ProviderManager::new();
-        manager.add(make_provider_with_model_rules(
-            "p",
-            &format!("http://{addr}"),
-            bedrock_compat(),
-            vec![ModelRule {
-                pattern: glob::Pattern::new("public-model-*").unwrap(),
-                rewrite: Some("internalmodel".to_owned()),
-            }],
-        ));
+        manager.add(
+            make_provider_with_model_rules(
+                "p",
+                &format!("http://{addr}"),
+                bedrock_compat(),
+                vec![ModelRule {
+                    pattern: glob::Pattern::new("public-model-*").unwrap(),
+                    rewrite: Some("internalmodel".to_owned()),
+                }],
+            )
+            .await,
+        );
         let app = crate::app::AppBuilder::new().manager(manager).build();
 
         // The original model is authorized
@@ -529,25 +529,31 @@ mod tests {
         compat.bedrock_model_invoke = true;
 
         let mut manager = ProviderManager::new();
-        manager.add(make_provider_with_model_rules(
-            "provider-a",
-            &format!("http://{addr}"),
-            compat.clone(),
-            vec![ModelRule {
-                pattern: glob::Pattern::new("*").unwrap(),
-                rewrite: None,
-            }],
-        ));
+        manager.add(
+            make_provider_with_model_rules(
+                "provider-a",
+                &format!("http://{addr}"),
+                compat.clone(),
+                vec![ModelRule {
+                    pattern: glob::Pattern::new("*").unwrap(),
+                    rewrite: None,
+                }],
+            )
+            .await,
+        );
 
-        manager.add(make_provider_with_model_rules(
-            "provider-b",
-            &format!("http://{addr}"),
-            compat,
-            vec![ModelRule {
-                pattern: glob::Pattern::new("gpt-4o").unwrap(),
-                rewrite: None,
-            }],
-        ));
+        manager.add(
+            make_provider_with_model_rules(
+                "provider-b",
+                &format!("http://{addr}"),
+                compat,
+                vec![ModelRule {
+                    pattern: glob::Pattern::new("gpt-4o").unwrap(),
+                    rewrite: None,
+                }],
+            )
+            .await,
+        );
 
         let app = crate::app::AppBuilder::new().manager(manager).build();
         let response = app

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,10 +44,12 @@ async fn main() {
 
     let mut manager = ProviderManager::new();
     for (key, provider_config) in &config.providers {
-        let provider = Provider::from_config(key, provider_config).unwrap_or_else(|e| {
-            error!(provider = %key, %e, "failed to configure provider");
-            std::process::exit(1);
-        });
+        let provider = Provider::from_config(key, provider_config)
+            .await
+            .unwrap_or_else(|e| {
+                error!(provider = %key, %e, "failed to configure provider");
+                std::process::exit(1);
+            });
         manager.add(provider);
     }
 

--- a/src/model_rules/mod.rs
+++ b/src/model_rules/mod.rs
@@ -46,13 +46,14 @@ mod tests {
         }
     }
 
-    fn provider_with_rules(rules: Vec<ModelRule>) -> Provider {
+    async fn provider_with_rules(rules: Vec<ModelRule>) -> Provider {
         crate::test_utils::make_provider_with_model_rules(
             "p",
             "http://example.com",
             Compatibility::default(),
             rules,
         )
+        .await
     }
 
     fn caps_with_rules(rules: Vec<ModelRule>) -> Capabilities {
@@ -66,18 +67,20 @@ mod tests {
         }
     }
 
-    #[test]
-    fn grant_rewrite_overrides_provider_on_identical_pattern() {
-        let provider = provider_with_rules(vec![model_rule("claude-*", Some("provider-target"))]);
+    #[tokio::test]
+    async fn grant_rewrite_overrides_provider_on_identical_pattern() {
+        let provider =
+            provider_with_rules(vec![model_rule("claude-*", Some("provider-target"))]).await;
         let caps = caps_with_rules(vec![model_rule("claude-*", Some("grant-target"))]);
         let merged = merge_model_rules(&provider, Some(&caps), None);
 
         assert_eq!(merged, vec![model_rule("claude-*", Some("grant-target"))]);
     }
 
-    #[test]
-    fn empty_grant_rule_does_not_remove_provider_rewrite() {
-        let provider = provider_with_rules(vec![model_rule("claude-*", Some("provider-target"))]);
+    #[tokio::test]
+    async fn empty_grant_rule_does_not_remove_provider_rewrite() {
+        let provider =
+            provider_with_rules(vec![model_rule("claude-*", Some("provider-target"))]).await;
         let caps = caps_with_rules(vec![model_rule("claude-*", None)]);
         let merged = merge_model_rules(&provider, Some(&caps), None);
 

--- a/src/provider/authenticator.rs
+++ b/src/provider/authenticator.rs
@@ -11,71 +11,63 @@ pub enum AuthenticatorError {
     },
 }
 
-pub(super) trait ProviderAuthenticator: std::fmt::Debug {
-    fn authenticate(&self, request: &mut reqwest::Request) -> Result<(), AuthenticatorError>;
+#[derive(Debug)]
+pub(super) enum Authenticator {
+    None,
+    Bearer {
+        key: String,
+    },
+    ApiKey {
+        header: reqwest::header::HeaderName,
+        key: String,
+    },
 }
 
-#[derive(Debug)]
-struct NoAuth;
+impl Authenticator {
+    pub(super) async fn authenticate(
+        &self,
+        request: &mut reqwest::Request,
+    ) -> Result<(), AuthenticatorError> {
+        match self {
+            Self::None => Ok(()),
 
-impl ProviderAuthenticator for NoAuth {
-    fn authenticate(&self, _request: &mut reqwest::Request) -> Result<(), AuthenticatorError> {
-        Ok(())
+            Self::Bearer { key } => {
+                let value = format!("Bearer {key}")
+                    .parse()
+                    .map_err(AuthenticatorError::InvalidBearerToken)?;
+                request
+                    .headers_mut()
+                    .insert(reqwest::header::AUTHORIZATION, value);
+                Ok(())
+            }
+
+            Self::ApiKey { header, key } => {
+                let value = key
+                    .parse()
+                    .map_err(|source| AuthenticatorError::InvalidApiKey {
+                        header: header.clone(),
+                        source,
+                    })?;
+                request.headers_mut().insert(header.clone(), value);
+                Ok(())
+            }
+        }
     }
 }
 
-#[derive(Debug)]
-struct BearerAuth {
-    key: String,
-}
-
-impl ProviderAuthenticator for BearerAuth {
-    fn authenticate(&self, request: &mut reqwest::Request) -> Result<(), AuthenticatorError> {
-        let value = format!("Bearer {}", self.key)
-            .parse()
-            .map_err(AuthenticatorError::InvalidBearerToken)?;
-        request
-            .headers_mut()
-            .insert(reqwest::header::AUTHORIZATION, value);
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-struct ApiKeyAuth {
-    header: reqwest::header::HeaderName,
-    key: String,
-}
-
-impl ProviderAuthenticator for ApiKeyAuth {
-    fn authenticate(&self, request: &mut reqwest::Request) -> Result<(), AuthenticatorError> {
-        let value = self
-            .key
-            .parse()
-            .map_err(|source| AuthenticatorError::InvalidApiKey {
-                header: self.header.clone(),
-                source,
-            })?;
-        request.headers_mut().insert(self.header.clone(), value);
-        Ok(())
-    }
-}
-
-pub(super) fn build_authenticator(
-    authorization: Option<&config::Authorization>,
-) -> Box<dyn ProviderAuthenticator + Send + Sync> {
+pub(super) fn build_authenticator(authorization: Option<&config::Authorization>) -> Authenticator {
     match authorization {
-        None => Box::new(NoAuth),
-        Some(config::Authorization::Bearer { apikey }) => Box::new(BearerAuth {
+        None => Authenticator::None,
+        Some(config::Authorization::Bearer { apikey }) => Authenticator::Bearer {
             key: apikey.clone(),
-        }),
-        Some(config::Authorization::XApiKey { apikey }) => Box::new(ApiKeyAuth {
+        },
+        Some(config::Authorization::XApiKey { apikey }) => Authenticator::ApiKey {
             header: reqwest::header::HeaderName::from_static("x-api-key"),
             key: apikey.clone(),
-        }),
-        Some(config::Authorization::XGoogApiKey { apikey }) => Box::new(ApiKeyAuth {
+        },
+        Some(config::Authorization::XGoogApiKey { apikey }) => Authenticator::ApiKey {
             header: reqwest::header::HeaderName::from_static("x-goog-api-key"),
             key: apikey.clone(),
-        }),
+        },
     }
 }

--- a/src/provider/manager.rs
+++ b/src/provider/manager.rs
@@ -37,25 +37,17 @@ mod tests {
     use crate::provider::compatibility::Compatibility;
     use crate::test_utils::make_provider;
 
-    #[test]
-    fn returns_matching_provider() {
+    #[tokio::test]
+    async fn returns_matching_provider() {
         let mut mgr = ProviderManager::new();
 
         let mut openai_compat = Compatibility::default();
         openai_compat.openai_chat = true;
-        mgr.add(make_provider(
-            "openai",
-            "https://example.com",
-            openai_compat,
-        ));
+        mgr.add(make_provider("openai", "https://example.com", openai_compat).await);
 
         let mut anthropic_compat = Compatibility::default();
         anthropic_compat.anthropic_messages = true;
-        mgr.add(make_provider(
-            "anthropic",
-            "https://example.com",
-            anthropic_compat,
-        ));
+        mgr.add(make_provider("anthropic", "https://example.com", anthropic_compat).await);
 
         let openai = mgr
             .get_for_api_type(&ApiType::OpenAiChatCompletion)
@@ -66,13 +58,13 @@ mod tests {
         assert_eq!(anthropic.name, "anthropic");
     }
 
-    #[test]
-    fn returns_none_when_no_match() {
+    #[tokio::test]
+    async fn returns_none_when_no_match() {
         let mut mgr = ProviderManager::new();
 
         let mut compat = Compatibility::default();
         compat.openai_chat = true;
-        mgr.add(make_provider("openai", "https://example.com", compat));
+        mgr.add(make_provider("openai", "https://example.com", compat).await);
 
         assert!(mgr.get_for_api_type(&ApiType::AnthropicMessages).is_none());
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, str::FromStr};
 use crate::authorization::{Authorization, Rule};
 use crate::config;
 use crate::model_rules::ModelRule;
-use authenticator::{ProviderAuthenticator, build_authenticator};
+use authenticator::{Authenticator, build_authenticator};
 use compatibility::Compatibility;
 
 pub use manager::ProviderManager;
@@ -66,13 +66,13 @@ pub struct Provider {
     pub authorizer: Authorization,
     client: reqwest::Client,
     headers: HashMap<String, String>,
-    authenticator: Box<dyn ProviderAuthenticator + Send + Sync>,
+    authenticator: Authenticator,
     pub compatibility: Compatibility,
     pub labels: HashMap<String, String>,
 }
 
 impl Provider {
-    pub fn from_config(key: &str, config: &config::Provider) -> Result<Self, anyhow::Error> {
+    pub async fn from_config(key: &str, config: &config::Provider) -> Result<Self, anyhow::Error> {
         let baseurl = reqwest::Url::parse(&config.baseurl)?;
         let authenticator = build_authenticator(config.authorization.as_ref());
         let model_patterns: Vec<glob::Pattern> = config
@@ -103,7 +103,7 @@ impl Provider {
         })
     }
 
-    pub fn build_request(
+    pub async fn build_request(
         &self,
         incoming: axum::extract::Request,
     ) -> Result<reqwest::Request, anyhow::Error> {
@@ -135,7 +135,7 @@ impl Provider {
             .headers(headers)
             .body(body)
             .build()?;
-        self.authenticator.authenticate(&mut request)?;
+        self.authenticator.authenticate(&mut request).await?;
         Ok(request)
     }
 
@@ -154,7 +154,7 @@ mod tests {
     use axum::http::Request;
     use std::collections::HashMap;
 
-    fn test_provider(
+    async fn test_provider(
         baseurl: &str,
         authorization: Option<config::Authorization>,
         headers: HashMap<String, String>,
@@ -179,6 +179,7 @@ mod tests {
                 labels: HashMap::new(),
             },
         )
+        .await
         .expect("test baseurl should be valid")
     }
 
@@ -192,22 +193,24 @@ mod tests {
 
     #[tokio::test]
     async fn rewrites_base_url() {
-        let provider = test_provider("https://api.anthropic.com", None, HashMap::new());
+        let provider = test_provider("https://api.anthropic.com", None, HashMap::new()).await;
         let req = provider
             .build_request(incoming_request("GET", "/v1/messages", Body::empty()))
+            .await
             .unwrap();
         assert_eq!(req.url().as_str(), "https://api.anthropic.com/v1/messages");
     }
 
     #[tokio::test]
     async fn preserves_base_url_path() {
-        let provider = test_provider("https://openrouter.ai/api/", None, HashMap::new());
+        let provider = test_provider("https://openrouter.ai/api/", None, HashMap::new()).await;
         let req = provider
             .build_request(incoming_request(
                 "GET",
                 "/v1/chat/completions",
                 Body::empty(),
             ))
+            .await
             .unwrap();
         assert_eq!(
             req.url().as_str(),
@@ -223,9 +226,11 @@ mod tests {
                 apikey: "sk-test-key".into(),
             }),
             HashMap::new(),
-        );
+        )
+        .await;
         let req = provider
             .build_request(incoming_request("POST", "/v1/chat", Body::empty()))
+            .await
             .unwrap();
         assert_eq!(
             req.headers().get("authorization").unwrap(),
@@ -241,9 +246,11 @@ mod tests {
                 apikey: "sk-ant-key".into(),
             }),
             HashMap::new(),
-        );
+        )
+        .await;
         let req = provider
             .build_request(incoming_request("POST", "/v1/messages", Body::empty()))
+            .await
             .unwrap();
         assert_eq!(req.headers().get("x-api-key").unwrap(), "sk-ant-key");
         assert!(req.headers().get("authorization").is_none());
@@ -257,18 +264,21 @@ mod tests {
                 apikey: "goog-key".into(),
             }),
             HashMap::new(),
-        );
+        )
+        .await;
         let req = provider
             .build_request(incoming_request("POST", "/v1/models", Body::empty()))
+            .await
             .unwrap();
         assert_eq!(req.headers().get("x-goog-api-key").unwrap(), "goog-key");
     }
 
     #[tokio::test]
     async fn no_auth() {
-        let provider = test_provider("https://example.com", None, HashMap::new());
+        let provider = test_provider("https://example.com", None, HashMap::new()).await;
         let req = provider
             .build_request(incoming_request("GET", "/health", Body::empty()))
+            .await
             .unwrap();
         assert!(req.headers().get("authorization").is_none());
         assert!(req.headers().get("x-api-key").is_none());
@@ -277,13 +287,14 @@ mod tests {
 
     #[tokio::test]
     async fn preserves_path() {
-        let provider = test_provider("https://api.example.com/", None, HashMap::new());
+        let provider = test_provider("https://api.example.com/", None, HashMap::new()).await;
         let req = provider
             .build_request(incoming_request(
                 "GET",
                 "/v1/models?limit=10",
                 Body::empty(),
             ))
+            .await
             .unwrap();
         assert_eq!(
             req.url().as_str(),
@@ -293,7 +304,7 @@ mod tests {
 
     #[tokio::test]
     async fn forwards_body() {
-        let provider = test_provider("https://api.example.com", None, HashMap::new());
+        let provider = test_provider("https://api.example.com", None, HashMap::new()).await;
         let payload = b"{\"prompt\":\"hello\"}";
         let req = provider
             .build_request(incoming_request(
@@ -301,6 +312,7 @@ mod tests {
                 "/v1/chat",
                 Body::from(payload.to_vec()),
             ))
+            .await
             .unwrap();
         assert_eq!(req.method(), "POST");
         assert_eq!(req.url().as_str(), "https://api.example.com/v1/chat");
@@ -322,9 +334,11 @@ mod tests {
                 apikey: "sk-key".into(),
             }),
             headers,
-        );
+        )
+        .await;
         let req = provider
             .build_request(incoming_request("POST", "/v1/chat", Body::empty()))
+            .await
             .unwrap();
         assert_eq!(req.headers().get("x-first-header").unwrap(), "foo");
         assert_eq!(req.headers().get("x-second-header").unwrap(), "bar");

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -32,15 +32,15 @@ pub async fn spawn_fixed_response_server(body: &'static str) -> std::net::Socket
     addr
 }
 
-pub fn make_provider(
+pub async fn make_provider(
     key: &str,
     baseurl: &str,
     compat: provider::compatibility::Compatibility,
 ) -> provider::Provider {
-    make_provider_with_model_rules(key, baseurl, compat, vec![])
+    make_provider_with_model_rules(key, baseurl, compat, vec![]).await
 }
 
-pub fn make_provider_with_model_rules(
+pub async fn make_provider_with_model_rules(
     key: &str,
     baseurl: &str,
     compat: provider::compatibility::Compatibility,
@@ -63,5 +63,6 @@ pub fn make_provider_with_model_rules(
             labels: HashMap::new(),
         },
     )
+    .await
     .unwrap()
 }


### PR DESCRIPTION
This is PR 1/3 to enable IAM auth support in Lacuna

# What is in this PR
- Essentially a no-op, preparing the code for subsequent PR
- Refactored authenticator from 1 struct per authentication scheme to an enum
- Making `build_request` async
- Adapted the rest of the code base for the new async function